### PR TITLE
Feature/bpc 8 avoid snake conflicts

### DIFF
--- a/src/logic/collision/otherSnakes.js
+++ b/src/logic/collision/otherSnakes.js
@@ -2,24 +2,32 @@ export default function checkOtherSnakesCollision(gameState, isMoveSafe) {
   const myHead = gameState.you.body[0];
   const opponents = gameState.board.snakes;
 
-  // Check each possible move for collisions with other snake bodies
-  const directions = {
+  const possibleMoves = {
     up: { x: myHead.x, y: myHead.y + 1 },
     down: { x: myHead.x, y: myHead.y - 1 },
     left: { x: myHead.x - 1, y: myHead.y },
     right: { x: myHead.x + 1, y: myHead.y },
   };
 
-  for (let snake of opponents) {
-    // Skip our own snake
-    if (snake.id === gameState.you.id) continue;
+  // Check all opponent snakes
+  for (const snake of opponents) {
+    if (snake.id === gameState.you.id) continue; // skip self
 
-    for (let segment of snake.body) {
-      for (let direction in directions) {
-        const target = directions[direction];
-        if (target.x === segment.x && target.y === segment.y) {
-          isMoveSafe[direction] = false;
+    // Check all body segments of the opponent snake
+    for (const segment of snake.body) {
+      for (const [direction, coord] of Object.entries(possibleMoves)) {
+        if (coord.x === segment.x && coord.y === segment.y) {
+          isMoveSafe[direction] = false; // mark unsafe if on body
         }
+      }
+    }
+
+    // **Add head-to-head prevention**
+    const opponentHead = snake.body[0]; // head of the opponent
+    for (const [direction, coord] of Object.entries(possibleMoves)) {
+      // If the move would land on the opponent's head, mark it unsafe
+      if (coord.x === opponentHead.x && coord.y === opponentHead.y) {
+        isMoveSafe[direction] = false;
       }
     }
   }

--- a/src/logic/collision/otherSnakes.js
+++ b/src/logic/collision/otherSnakes.js
@@ -1,4 +1,28 @@
 export default function checkOtherSnakesCollision(gameState, isMoveSafe) {
-    //BPC-6 2 Prevent Wall Collisions in Movement Logic
-    return isMoveSafe;
+  const myHead = gameState.you.body[0];
+  const opponents = gameState.board.snakes;
+
+  // Check each possible move for collisions with other snake bodies
+  const directions = {
+    up: { x: myHead.x, y: myHead.y + 1 },
+    down: { x: myHead.x, y: myHead.y - 1 },
+    left: { x: myHead.x - 1, y: myHead.y },
+    right: { x: myHead.x + 1, y: myHead.y },
+  };
+
+  for (let snake of opponents) {
+    // Skip our own snake
+    if (snake.id === gameState.you.id) continue;
+
+    for (let segment of snake.body) {
+      for (let direction in directions) {
+        const target = directions[direction];
+        if (target.x === segment.x && target.y === segment.y) {
+          isMoveSafe[direction] = false;
+        }
+      }
+    }
   }
+
+  return isMoveSafe;
+}


### PR DESCRIPTION
Added logic to the checkOtherSnakesCollision function to prevent the snake from colliding with other snakes, including head-to-head collisions. The function now checks if a potential move will land on any part of an opponent’s body or head, marking such moves as unsafe.